### PR TITLE
Route to Home/Index when click on TrangChu on navbar

### DIFF
--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -20,6 +20,12 @@ class IndexController extends Controller
     public function index(){
         $config = $this->configService->find(1);//By default there should be only one record, so ID = 1
         $courses = $this-> courseService->indexAPI();
-        return view('client.layouts.index',compact("config","courses"));
+        $isSPA=false;
+        //Checking if page is loaded directly or through spa
+        if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest') {
+            $isSPA=true;
+        }
+
+        return view('client.layouts.index',compact("config","courses","isSPA"));
     }
 }

--- a/app/Service/ContactService.php
+++ b/app/Service/ContactService.php
@@ -54,14 +54,15 @@ class ContactService {
         $contact = new Contact();
         $contact = new ContactResource($contact);
         $courses = Course::all();
-        $section = "content";
-        $extends="client.master";
+        //        $section = "content";
+//        $extends="client.master";
+        $isSPA=false;
         if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest') {
-            $extends="client.contact.spa";//Dummy extends if page already called by master layout
+//            $extends="client.layouts.spa";//Dummy extends if page already called by master layout
+            $isSPA=true;
         }
-        //Send email here
 
-        return view("client.contact.create", compact("contact", "config", "courses","extends","section"));
+        return view("client.contact.create", compact("contact", "config", "courses","isSPA"));
 
     }
 

--- a/resources/views/client/contact/create.blade.php
+++ b/resources/views/client/contact/create.blade.php
@@ -1,5 +1,9 @@
+@php $extends = $isSPA ? 'client.layouts.spa' : 'client.master'; @endphp
+{{--If page is loaded directly by another page( then no need to extends/or just extends to a dummy page)--}}
+{{--If page is loaded directly then extends to master layout--}}
 @extends($extends)
-@section($section)
+
+@section("content")
     {{--    <link rel="stylesheet" href="{{asset("assets/css/bootstrap.min.css")}}">--}}
     <link type="text/css" rel="stylesheet" href="https://unpkg.com/bs-brain@2.0.4/utilities/bsb-overlay/bsb-overlay.css">
     <link type="text/css" rel="stylesheet" href="https://unpkg.com/bs-brain@2.0.4/utilities/background/background.css">

--- a/resources/views/client/layouts/index.blade.php
+++ b/resources/views/client/layouts/index.blade.php
@@ -1,5 +1,8 @@
-@extends('client.master')
-@section('content')
+@php $extends = $isSPA ? 'client.layouts.spa' : 'client.master'; @endphp
+@extends($extends)
+{{--If page is loaded directly by another page( then no need to extends/or just extends to a dummy page)--}}
+{{--If page is loaded directly then extends to master layout--}}
+@section("content")
 <div>
     <div class="banner-home overflow-hidden pt-lg-100 pt-md-90 pt-sm-80 pt-xs-70">
         <div class="container">

--- a/resources/views/client/layouts/spa.blade.php
+++ b/resources/views/client/layouts/spa.blade.php
@@ -1,3 +1,4 @@
 @yield("content")
 {{--will break contact.create.blade.php if deleted--}}
+is dummy file. If page is loaded directly, will use default section
 

--- a/resources/views/client/master.blade.php
+++ b/resources/views/client/master.blade.php
@@ -107,7 +107,7 @@
                                 <div class="main-menu">
                                     <ul>
                                         <li>
-                                            <a href="#">Trang chủ</a>
+                                            <a data-spa href="{{route("home")}}">Trang chủ</a>
                                         </li>
                                         <li>
                                             <a href="#">Giới thiệu</a>
@@ -170,7 +170,7 @@
                             <a href="#">Home</a>
                             <ul>
                                 <li>
-                                    <a href="#">Trang chủ</a>
+                                    <a data-spa href="{{route("home")}}">Trang chủ</a>
                                 </li>
                                 <li>
                                     <a href="#">Giới thiệu</a>
@@ -182,7 +182,7 @@
                                     <a href="#">Tin tức</a>
                                 </li>
                                 <li>
-                                    <a href="#">Liên hệ</a>
+                                    <a href="{{route('contact.create')}}" data-spa>Liên hệ</a>
                                 </li>
                             </ul>
                 </div>


### PR DESCRIPTION
Trỏ đến trang chủ khi nhấn vào Trang chủ trên thanh điều hướng(màn hình lớn) hoặc hamburger sidebar(màn hình nhỏ)

Thay đổi SPA: sử dụng @php $extends = $isSPA ? 'client.layouts.spa' : 'client.master'; @endphp
- Nếu trang được tải trực tiếp thì thực hiện extends đến một master layout
- Nếu trang được chuyển hướng tới thì thực hiện extends đến một view rỗng